### PR TITLE
slightly better karma.conf.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .DS_Store
 .bowerrc
 .gitattributes
+/coverage

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,20 +1,26 @@
 // Karma configuration
 // Generated on Sat Feb 13 2016 14:09:31 GMT+0530 (IST)
 
-module.exports = function(config) {
+module.exports = function (config) {
+  'use strict';
+
   config.set({
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch : true,
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '',
+    basePath : '',
 
-
-    // frameworks to use
+    // testing framework to use (jasmine/mocha/qunit/...)
+    // as well as any additional frameworks (requirejs/chai/sinon/...)
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['jasmine'],
-
+    frameworks : [
+      'jasmine'
+    ],
 
     // list of files / patterns to load in the browser
-    files: [
+    files : [
+      // bower:js
       'bower_components/jquery/dist/jquery.js',
       'bower_components/angular/angular.js',
       'bower_components/bootstrap/dist/js/bootstrap.js',
@@ -25,58 +31,115 @@ module.exports = function(config) {
       'bower_components/angular-sanitize/angular-sanitize.js',
       'bower_components/angular-touch/angular-touch.js',
       'bower_components/angular-mocks/angular-mocks.js',
-      'app/scripts/*.js',
-      'app/scripts/services/*.js',
-      'app/scripts/controllers/*.js',
-      'test/**/*.js'
+      // endbower
+      'test/spec/**/*.js',
+      'app/scripts/**/*.js',
+      // view templates
+      'app/views/**/*.html'
     ],
 
+    // list of files / patterns to exclude
+    exclude : [],
 
-    // list of files to exclude
-    exclude: [
-    ],
-
-
-    // preprocess matching files before serving them to the browser
+    // pre-process matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
+    preprocessors : {
+      // pre-process HTML files into AngularJS templates.
+      'app/views/**/*.html' : ['ng-html2js'],
+      // source files, that you wanna generate coverage for
+      // do not include tests or libraries
+      // (these files will be instrumented by Istanbul)
+      'app/scripts/**/*.js' : ['coverage']
     },
-
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
-
+    // coverage reporter generates the coverage
+    reporters : ['spec', 'coverage'],
 
     // web server port
-    port: 9876,
+    port : 9876,
 
-
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
-
-
-    // level of logging
-    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_DEBUG,
-
-
-    // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
-
-
-    // start these browsers
+    // Start these browsers, currently available:
+    // - Chrome
+    // - ChromeCanary
+    // - Firefox
+    // - Opera
+    // - Safari (only Mac)
+    // - PhantomJS
+    // - IE (only Windows)
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers : [
+      'PhantomJS'
+    ],
 
+    // Which plugins to enable
+    plugins : [
+      'karma-phantomjs-launcher',
+      'karma-jasmine',
+      'karma-spec-reporter',
+      'karma-coverage',
+      'karma-ng-html2js-preprocessor'
+    ],
 
     // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false,
+    // if true, it capture browsers, run tests and exit
+    singleRun : false,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors : true,
+
+    // level of logging
+    // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
+    logLevel : config.LOG_DEBUG,
+
+    // Uncomment the following lines if you are using grunt's server to run the tests
+    // proxies: {
+    //   '/': 'http://localhost:9000/'
+    // },
+    // URL root prevent conflicts with the site root
+    // urlRoot: '_karma_'
+
 
     // Concurrency level
     // how many browser should be started simultaneous
-    concurrency: Infinity
-  })
+    concurrency: Infinity,
+
+    specReporter : {maxLogLines : 10},
+
+    // configure the html2js preprocessor
+    ngHtml2JsPreprocessor : {
+      //// strip this from the file path
+      //stripPrefix   : 'public/',
+      //stripSuffix   : '.ext',
+      //// prepend this to the
+      //prependPrefix : 'served/',
+
+      // or define a custom transform function
+      //cacheIdFromPath : function (filepath) {
+      //  return cacheId;
+      //},
+
+      // - setting this option will create only a single module that contains templates
+      //   from all the files, so you can load them all with module('foo')
+      // - you may provide a function(htmlPath, originalPath) instead of a string
+      //   if you'd like to generate modules dynamically
+      //   htmlPath is a originalPath stripped and/or prepended
+      //   with all provided suffixes and prefixes
+      // moduleName : 'calendarViews'
+    },
+
+    // configure the reporter
+    coverageReporter : {
+      dir       : 'coverage/',
+      reporters : [
+        // reporters not supporting the `file` property
+        {type : 'html', subdir : 'report-html'},
+        {type : 'text'},
+        {type : 'text-summary'}
+      ]
+    }
+  });
 };
+

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
     "jit-grunt": "^0.9.1",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.13.19",
+    "karma-coverage": "^0.5.3",
     "karma-jasmine": "^0.3.7",
     "karma-ng-html2js-preprocessor": "^0.2.1",
     "karma-ng-scenario": "^0.1.0",
     "karma-phantomjs-launcher": "^1.0.0",
+    "karma-spec-reporter": "0.0.24",
     "phantomjs": "^2.1.3",
     "phantomjs-prebuilt": "^2.1.4",
     "time-grunt": "^1.0.0"


### PR DESCRIPTION
While the fix pushed to master will get you going writing unit tests, see the enhanced `karma.conf.js` borrowed from [here](https://github.com/kollavarsham/calendar/blob/master/test/karma.conf.js) applied along with the additional `coverage` and other plugins.

Notice how the tests are reported in the `BDD` or `spec` style along with a table listing code/test coverage:

```
  Service: dummyService
    ✓ should do something

  Service: voucherStates
    ✓ Voucher should move from draft to submitted state regardless of approval
    ✓ Submitted voucher should move to rejected if not approved
    ✓ Submitted voucher should move to approved if approve is true

PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 4 of 4 SUCCESS (0.007 secs / 0.024 secs)
TOTAL: 4 SUCCESS

----------------------|----------|----------|----------|----------|----------------|
File                  |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------|----------|----------|----------|----------|----------------|
 scripts/             |      100 |      100 |      100 |      100 |                |
  app.js              |      100 |      100 |      100 |      100 |                |
 scripts/controllers/ |    14.29 |      100 |        0 |    14.29 |                |
  edit-voucher.js     |       50 |      100 |        0 |       50 |             17 |
  main.js             |    10.53 |      100 |        0 |    10.53 |... 43,44,50,54 |
 scripts/services/    |    23.88 |    14.29 |    21.62 |    24.24 |                |
  dummyservice.js     |      100 |      100 |      100 |      100 |                |
  lb-services.js      |    20.35 |    17.24 |    17.65 |    20.72 |... 9,2460,2462 |
  voucherstates.js    |    36.84 |        0 |       50 |    36.84 |... 32,33,35,37 |
----------------------|----------|----------|----------|----------|----------------|
All files             |    24.53 |    14.29 |    18.37 |    24.84 |                |
----------------------|----------|----------|----------|----------|----------------|


=============================== Coverage summary ===============================
Statements   : 24.53% ( 39/159 )
Branches     : 14.29% ( 5/35 )
Functions    : 18.37% ( 9/49 )
Lines        : 24.84% ( 39/157 )
================================================================================
20 02 2016 00:07:51.919:DEBUG [karma]: Run complete, exiting.
20 02 2016 00:07:51.919:DEBUG [launcher]: Disconnecting all browsers
20 02 2016 00:07:51.925:DEBUG [launcher]: Process PhantomJS exited with code 0
20 02 2016 00:07:51.925:DEBUG [temp-dir]: Cleaning temp dir /var/folders/lx/359_25ws4zs3clff5n5n3bl00000gn/T/karma-57515861
20 02 2016 00:07:51.929:DEBUG [coverage]: Writing coverage to /Users/hari/Source/Sandbox/ExpenseVoucher-WebClient/coverage/report-html
20 02 2016 00:07:52.048:DEBUG [launcher]: Finished all browsers

Done, without errors.
```

Also note, if you open `coverage/report-html/index.html` you can see an interactive report with line coverage information, generated by [istanbul](https://github.com/gotwarlost/istanbul)

There is also the `bower & endbower` markers within the `karma.conf.js` (that automatically adds a new angular module into karma.conf for you) as well as the [karma-ng-html2js-preprocessor](https://github.com/karma-runner/karma-ng-html2js-preprocessor) plugin, which is quite useful in unit testing directives and their associated views (check our calendar tests for examples).